### PR TITLE
Decode and encode source text with unicode-escape.

### DIFF
--- a/TriagerScoring.py
+++ b/TriagerScoring.py
@@ -84,7 +84,7 @@ def importData(input_file, output_file, excludedUsers = []):
                 flags = cat_data['case_number'].tolist()
                 namespaces = cat_data['namespace'].tolist()
                 length = floor(cat_data['source_text_length'].tolist()[0])
-                texts = cat_data['target_text'].tolist()
+                texts = cat_data['target_text'].str.decode('unicode-escape').tolist()
 
                 print('//Article:', a, 'Category:', c, 'numUsers:', numUsers)
                 source_text = addToSourceText(starts, ends, texts, source_text)
@@ -105,6 +105,7 @@ def appendData(article_filename, article_sha256, namespaces,start_pos_list, end_
         case_numbers = np.zeros(len(start_pos_list))
     for i in range(len(start_pos_list)):
         text = getText(start_pos_list[i], end_pos_list[i],source_text)
+        text = text.encode('unicode-escape').decode('utf-8')
         print(len(namespaces), len(start_pos_list), len(end_pos_list), len(case_numbers))
         data.append([article_filename, article_sha256, namespaces[i], start_pos_list[i], end_pos_list[i], topic_name, int(case_numbers[i]), text])
     return data


### PR DESCRIPTION
The input data target_text column is now encoded in 'unicode-escape' format.

This PR adjusts the TriagerScoring code to decode this format on the way in, and encode in this format on saving.

For example, the following is True on Python2 and 3.
u"€".encode("unicode-escape") == b"\u20ac"

However len(u"€") == 1, and len(b"\u20ac") == 6.

So for various copying operations to be correct such as addToSourceText, the characters have to be put back into regular unicode.

The reason for the encoding is that it is highly preferable to not have line feeds in quoted text in the CSV output.